### PR TITLE
new indexes operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ var userInfo = UserInfo{
 Create index
 
 ```go
-cli.EnsureIndexes(ctx, []string{}, []string{"age", "name,weight"})
+cli.CreateOneIndex(context.Background(), options.IndexModel{Key: []string{"name"}, Unique: true})
+cli.CreateIndexes(context.Background(), []options.IndexModel{{Key: []string{"id2", "id3"}}})
 ```
 
 - Insert a document

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -92,7 +92,8 @@ var userInfo = UserInfo{
 创建索引
 
 ```go
-cli.EnsureIndexes(ctx, []string{}, []string{"age", "name,weight"})
+cli.CreateOneIndex(context.Background(), options.IndexModel{Key: []string{"name"}, Unique: true})
+cli.CreateIndexes(context.Background(), []options.IndexModel{{Key: []string{"id2", "id3"}}})
 ```
 
 - 插入一个文档

--- a/collection.go
+++ b/collection.go
@@ -330,7 +330,7 @@ func (c *Collection) ensureIndex(ctx context.Context, indexes []opts.IndexModel)
 	return nil
 }
 
-// EnsureIndexes Deprecated,
+// EnsureIndexes Deprecated
 // Recommend to use CreateIndexes / CreateOneIndex for more function)
 // EnsureIndexes creates unique and non-unique indexes in collection
 // the combination of indexes is different from CreateIndexes:

--- a/options/index_options.go
+++ b/options/index_options.go
@@ -1,0 +1,9 @@
+package options
+
+type IndexModel struct {
+	Key                []string // Index key fields; prefix name with dash (-) for descending order
+	Unique             bool     // Prevent two documents from having the same index key
+	Background         bool     // Build index in background and return immediately
+	Sparse             bool     // Only index documents containing the Key fields
+	ExpireAfterSeconds *int32   // Periodically delete docs with indexed time.Time older than that.
+}


### PR DESCRIPTION
Fix #91 
- Support new options to indexes operation
```go
	Unique             bool     // Prevent two documents from having the same index key
	Background         bool     // Build index in background and return immediately
	Sparse             bool     // Only index documents containing the Key fields
	ExpireAfterSeconds *int32   // Periodically delete docs with indexed time.Time older than that.
```
- Introduce new API `CreateOneIndex` and `CreateIndexes`,
- Deprecated `EnsureIndexes`