### PR TITLE
API: add NewClientFromDriver to create qmgo.Client from official driver

### DIFF
--- a/client.go
+++ b/client.go
@@ -127,9 +127,7 @@ func Open(ctx context.Context, conf *Config, o ...options.ClientOptions) (cli *Q
 
 // Client creates client to mongo
 type Client struct {
-	client *mongo.Client
-	conf   Config
-
+	client   *mongo.Client
 	registry *bsoncodec.Registry
 }
 
@@ -146,7 +144,17 @@ func NewClient(ctx context.Context, conf *Config, o ...options.ClientOptions) (c
 	}
 	cli = &Client{
 		client:   client,
-		conf:     *conf,
+		registry: opt.Registry,
+	}
+	return
+}
+
+// NewClientFromOfficial creates Qmgo MongoDB client from official mongo driver
+func NewClientFromDriver(client *mongo.Client, o ...*officialOpts.ClientOptions) (cli *Client) {
+	opt := officialOpts.MergeClientOptions(o...)
+
+	cli = &Client{
+		client:   client,
 		registry: opt.Registry,
 	}
 	return


### PR DESCRIPTION
Through this API, people using mongodb official driver can also quickly switch to qmgo API.

conf field in qmgo.Client has no reference so I deleted it for consistency.

